### PR TITLE
Generic Error Responder for JSON Responses

### DIFF
--- a/jsonresp/error.go
+++ b/jsonresp/error.go
@@ -7,40 +7,40 @@ import (
 )
 
 // Ensure errorResponder implements Responder.
-var _ httphandler.Responder = (*errorResponder)(nil)
+var _ httphandler.Responder = (*errorResponder[any])(nil)
 
 // Error creates a standardized error response with the specified error message and HTTP status code.
 // The 'err' parameter can be used for internal logging.
-func Error(err error, message string, code int) *errorResponder {
-	return &errorResponder{
+func Error[T any](err error, errData T, code int) *errorResponder[T] {
+	return &errorResponder[T]{
 		statusCode: code,
-		errMessage: message,
+		errData:    errData,
 		err:        err,
 	}
 }
 
 // InternalServerError creates a standardized internal server error response.
 // The 'err' parameter can be used for internal logging.
-func InternalServerError(err error) *errorResponder {
-	return &errorResponder{
+func InternalServerError(err error) *errorResponder[string] {
+	return &errorResponder[string]{
 		statusCode: http.StatusInternalServerError,
-		errMessage: "Internal Server Error",
+		errData:    "Internal Server Error",
 		err:        err,
 	}
 }
 
 // errorResponder handles error JSON HTTP responses.
-type errorResponder struct {
+type errorResponder[T any] struct {
 	logger     httphandler.Logger
 	header     http.Header
 	statusCode int
 	cookies    []*http.Cookie
-	errMessage string
+	errData    T
 	err        error
 }
 
 // Respond sends the JSON error response with custom headers, cookies, and status code.
-func (res *errorResponder) Respond(w http.ResponseWriter, _ *http.Request) {
+func (res *errorResponder[T]) Respond(w http.ResponseWriter, _ *http.Request) {
 	// Set cookies.
 	for _, cookie := range res.cookies {
 		http.SetCookie(w, cookie)
@@ -54,18 +54,18 @@ func (res *errorResponder) Respond(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	// Write the error JSON response.
-	writeJSON(w, map[string]string{"error": res.errMessage}, res.statusCode, res.logger)
+	writeJSON(w, map[string]T{"error": res.errData}, res.statusCode, res.logger)
 	httphandler.LogRequestError(res.logger, res.err)
 }
 
 // WithLogger sets the logger for the responder.
-func (res *errorResponder) WithLogger(logger httphandler.Logger) *errorResponder {
+func (res *errorResponder[T]) WithLogger(logger httphandler.Logger) *errorResponder[T] {
 	res.logger = logger
 	return res
 }
 
 // WithHeader adds a custom header to the response.
-func (res *errorResponder) WithHeader(key, value string) *errorResponder {
+func (res *errorResponder[T]) WithHeader(key, value string) *errorResponder[T] {
 	if res.header == nil {
 		res.header = http.Header{}
 	}
@@ -74,7 +74,7 @@ func (res *errorResponder) WithHeader(key, value string) *errorResponder {
 }
 
 // WithCookie adds a cookie to the response.
-func (res *errorResponder) WithCookie(cookie *http.Cookie) *errorResponder {
+func (res *errorResponder[T]) WithCookie(cookie *http.Cookie) *errorResponder[T] {
 	res.cookies = append(res.cookies, cookie)
 	return res
 }

--- a/jsonresp/error_test.go
+++ b/jsonresp/error_test.go
@@ -29,12 +29,20 @@ func TestError_Respond(t *testing.T) {
 		wantBody    string
 	}{
 		{
-			desc:        "basic",
+			desc:        "basic | string",
 			given:       jsonresp.Error(errors.New("invalid id"), "Invalid ID provided", http.StatusBadRequest),
 			wantCode:    http.StatusBadRequest,
 			wantHeaders: nil,
 			wantCookies: nil,
 			wantBody:    `{"error":"Invalid ID provided"}`,
+		},
+		{
+			desc:        "basic | map",
+			given:       jsonresp.Error(errors.New("invalid id"), map[string][]string{"id": {"Invalid ID provided"}}, http.StatusBadRequest),
+			wantCode:    http.StatusBadRequest,
+			wantHeaders: nil,
+			wantCookies: nil,
+			wantBody:    `{"error":{"id":["Invalid ID provided"]}}`,
 		},
 		{
 			desc: "with everything",


### PR DESCRIPTION
This PR enhances the `jsonresp` package by making the error responder generic, allowing for more complex error data structures while maintaining full backward compatibility.

## Changes

- Converted `errorResponder` to use generics with `errorResponder[T any]`
- Renamed `errMessage` field to `errData` to better reflect its purpose
- Updated the `Error()` function to accept any type as error data
- Maintained backward compatibility with string error messages
- `InternalServerError()` continues to work as before, now explicitly using string type

## Benefits

- **More Expressive Errors**: Now supports structured error data beyond simple strings
- **Type Safety**: Leverages Go's type system for better compile-time checks
- **Backward Compatible**: All existing code using string error messages continues to work
- **Consistent API**: Maintains the same fluent interface pattern

## Example Usage

```go
// Simple string errors (unchanged behavior)
jsonresp.Error(err, "Invalid request", http.StatusBadRequest)

// Structured error data
jsonresp.Error(err, map[string][]string{
    "id": {"Must be a valid UUID"},
    "email": {"Required", "Must be a valid email address"},
}, http.StatusBadRequest)

// Custom error types
jsonresp.Error(err, MyErrorType{Code: "INVALID_INPUT", Details: []string{"..."}}, http.StatusBadRequest)
```

This change enables more detailed and structured error responses while preserving the simplicity of the API.
