### PR TITLE
jsonresp: remove top level error key, allow caller to define the entire error json response

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ router.HandleFunc("GET /users/{id}", func(w http.ResponseWriter, r *http.Request
 router.HandleFunc("GET /users/{id}", httphandler.Handle(func(r *http.Request) httphandler.Responder {
     user := getUser(r.PathValue("id"))
     if user == nil {
-        return jsonresp.Error(nil, "User not found", http.StatusNotFound)
+        return jsonresp.Error(nil, &ErrorResponse{
+            Code:    "NOT_FOUND",
+            Message: "User not found",
+        }, http.StatusNotFound)
     }
     return jsonresp.Success(user)
 }))
@@ -79,7 +82,10 @@ func getUserHandler(r *http.Request) httphandler.Responder {
         return jsonresp.InternalServerError(err)
     }
     if user == nil {
-        return jsonresp.Error(nil, "User not found", http.StatusNotFound)
+        return jsonresp.Error(nil, &ErrorResponse{
+            Code:    "NOT_FOUND",
+            Message: "User not found",
+        }, http.StatusNotFound)
     }
     return jsonresp.Success(user)
 }
@@ -134,7 +140,11 @@ return jsonresp.Success(data).
 ```go
 func createUserHandler(r *http.Request, input CreateUserInput) httphandler.Responder {
     if err := input.Validate(); err != nil {
-        return jsonresp.Error(err, "Invalid input", http.StatusBadRequest)
+        return jsonresp.Error(err, &ValidationError{
+            Code:    "VALIDATION_ERROR",
+            Message: "Invalid input",
+            Details: err.Error(),
+        }, http.StatusBadRequest)
     }
     
     user, err := createUser(input)

--- a/examples/main.go
+++ b/examples/main.go
@@ -66,7 +66,11 @@ func main() {
 
 func createUser(r *http.Request, input UserInput) httphandler.Responder {
 	if err := validate(input); err != nil {
-		return jsonresp.Error(err, err.Error(), http.StatusBadRequest)
+		return jsonresp.Error(err, &map[string]any{
+			"code":    "VALIDATION_ERROR",
+			"message": "Invalid input data",
+			"details": err.Error(),
+		}, http.StatusBadRequest)
 	}
 
 	user := User{
@@ -84,7 +88,11 @@ func getUser(r *http.Request) httphandler.Responder {
 	id := r.PathValue("id")
 	user, exists := users[id]
 	if !exists {
-		return jsonresp.Error(nil, "User not found", http.StatusNotFound)
+		return jsonresp.Error(nil, &map[string]any{
+			"code":        "NOT_FOUND",
+			"message":     "User not found",
+			"resource_id": id,
+		}, http.StatusNotFound)
 	}
 
 	return jsonresp.Success(&user)
@@ -102,11 +110,19 @@ func updateUser(r *http.Request, input UserInput) httphandler.Responder {
 	id := r.PathValue("id")
 	user, exists := users[id]
 	if !exists {
-		return jsonresp.Error(nil, "User not found", http.StatusNotFound)
+		return jsonresp.Error(nil, &map[string]any{
+			"code":        "NOT_FOUND",
+			"message":     "User not found",
+			"resource_id": id,
+		}, http.StatusNotFound)
 	}
 
 	if err := validate(input); err != nil {
-		return jsonresp.Error(err, err.Error(), http.StatusBadRequest)
+		return jsonresp.Error(err, &map[string]any{
+			"code":    "VALIDATION_ERROR",
+			"message": "Invalid input data",
+			"details": err.Error(),
+		}, http.StatusBadRequest)
 	}
 
 	user.Name = input.Name
@@ -119,7 +135,11 @@ func updateUser(r *http.Request, input UserInput) httphandler.Responder {
 func deleteUser(r *http.Request) httphandler.Responder {
 	id := r.PathValue("id")
 	if _, exists := users[id]; !exists {
-		return jsonresp.Error(nil, "User not found", http.StatusNotFound)
+		return jsonresp.Error(nil, &map[string]any{
+			"code":        "NOT_FOUND",
+			"message":     "User not found",
+			"resource_id": id,
+		}, http.StatusNotFound)
 	}
 
 	delete(users, id)

--- a/jsonresp/error.go
+++ b/jsonresp/error.go
@@ -11,10 +11,10 @@ var _ httphandler.Responder = (*errorResponder[any])(nil)
 
 // Error creates a standardized error response with the specified error message and HTTP status code.
 // The 'err' parameter can be used for internal logging.
-func Error[T any](err error, errData T, code int) *errorResponder[T] {
+func Error[T any](err error, data *T, code int) *errorResponder[T] {
 	return &errorResponder[T]{
 		statusCode: code,
-		errData:    errData,
+		data:       data,
 		err:        err,
 	}
 }
@@ -22,9 +22,10 @@ func Error[T any](err error, errData T, code int) *errorResponder[T] {
 // InternalServerError creates a standardized internal server error response.
 // The 'err' parameter can be used for internal logging.
 func InternalServerError(err error) *errorResponder[string] {
+	s := "Internal Server Error"
 	return &errorResponder[string]{
 		statusCode: http.StatusInternalServerError,
-		errData:    "Internal Server Error",
+		data:       &s,
 		err:        err,
 	}
 }
@@ -35,7 +36,7 @@ type errorResponder[T any] struct {
 	header     http.Header
 	statusCode int
 	cookies    []*http.Cookie
-	errData    T
+	data       *T
 	err        error
 }
 
@@ -54,7 +55,7 @@ func (res *errorResponder[T]) Respond(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	// Write the error JSON response.
-	writeJSON(w, map[string]T{"error": res.errData}, res.statusCode, res.logger)
+	writeJSON(w, res.data, res.statusCode, res.logger)
 	httphandler.LogRequestError(res.logger, res.err)
 }
 

--- a/jsonresp/error_test.go
+++ b/jsonresp/error_test.go
@@ -15,6 +15,18 @@ import (
 func TestError_Respond(t *testing.T) {
 	t.Parallel()
 
+	type ValidationError struct {
+		Field   string   `json:"field"`
+		Message string   `json:"message"`
+		Details []string `json:"details,omitempty"`
+	}
+
+	type ErrorResponse struct {
+		Code    string            `json:"code"`
+		Message string            `json:"message"`
+		Errors  []ValidationError `json:"errors,omitempty"`
+	}
+
 	cookie := &http.Cookie{
 		Name:  "test-cookie-1",
 		Value: "cookie-value-1",
@@ -29,32 +41,71 @@ func TestError_Respond(t *testing.T) {
 		wantBody    string
 	}{
 		{
+			desc:        "basic | nil",
+			given:       jsonresp.Error[any](errors.New("unexpected error"), nil, http.StatusInternalServerError),
+			wantCode:    http.StatusInternalServerError,
+			wantHeaders: nil,
+			wantCookies: nil,
+			wantBody:    `null`,
+		},
+		{
 			desc:        "basic | string",
-			given:       jsonresp.Error(errors.New("invalid id"), "Invalid ID provided", http.StatusBadRequest),
+			given:       jsonresp.Error(errors.New("invalid id"), ptr("Invalid ID provided"), http.StatusBadRequest),
 			wantCode:    http.StatusBadRequest,
 			wantHeaders: nil,
 			wantCookies: nil,
-			wantBody:    `{"error":"Invalid ID provided"}`,
+			wantBody:    `"Invalid ID provided"`,
+		},
+		{
+			desc:        "basic | slice",
+			given:       jsonresp.Error(errors.New("invalid id"), &[]string{"Required field", "Invalid format"}, http.StatusBadRequest),
+			wantCode:    http.StatusBadRequest,
+			wantHeaders: nil,
+			wantCookies: nil,
+			wantBody:    `["Required field","Invalid format"]`,
 		},
 		{
 			desc:        "basic | map",
-			given:       jsonresp.Error(errors.New("invalid id"), map[string][]string{"id": {"Invalid ID provided"}}, http.StatusBadRequest),
+			given:       jsonresp.Error(errors.New("validation failed"), &map[string]string{"email": "Invalid email format", "password": "Too short"}, http.StatusBadRequest),
 			wantCode:    http.StatusBadRequest,
 			wantHeaders: nil,
 			wantCookies: nil,
-			wantBody:    `{"error":{"id":["Invalid ID provided"]}}`,
+			wantBody:    `{"email":"Invalid email format","password":"Too short"}`,
+		},
+		{
+			desc: "basic | struct",
+			given: jsonresp.Error(
+				errors.New("validation failed"),
+				&ErrorResponse{
+					Code:    "VALIDATION_ERROR",
+					Message: "The request contains invalid parameters",
+					Errors: []ValidationError{
+						{Field: "email", Message: "Invalid email format", Details: []string{"Must contain @", "Domain must be valid"}},
+						{Field: "password", Message: "Password too weak", Details: []string{"Must be at least 8 characters", "Must contain a number"}},
+					},
+				},
+				http.StatusBadRequest,
+			),
+			wantCode:    http.StatusBadRequest,
+			wantHeaders: nil,
+			wantCookies: nil,
+			wantBody:    `{"code":"VALIDATION_ERROR","message":"The request contains invalid parameters","errors":[{"field":"email","message":"Invalid email format","details":["Must contain @","Domain must be valid"]},{"field":"password","message":"Password too weak","details":["Must be at least 8 characters","Must contain a number"]}]}`,
 		},
 		{
 			desc: "with everything",
-			given: jsonresp.Error(errors.New("post not found"), "Post not found", http.StatusNotFound).
-				WithHeader("X-Test-1", "test value 1").
+			given: jsonresp.Error(
+				errors.New("resource not found"),
+				&map[string]string{"code": "NOT_FOUND", "message": "The requested resource was not found"},
+				http.StatusNotFound,
+			).
+				WithHeader("X-Request-ID", "abc123").
 				WithCookie(cookie),
 			wantCode: http.StatusNotFound,
 			wantHeaders: map[string]string{
-				"X-Test-1": "test value 1",
+				"X-Request-ID": "abc123",
 			},
 			wantCookies: []*http.Cookie{cookie},
-			wantBody:    `{"error":"Post not found"}`,
+			wantBody:    `{"code":"NOT_FOUND","message":"The requested resource was not found"}`,
 		},
 	}
 
@@ -76,10 +127,18 @@ func TestError_Respond(t *testing.T) {
 			}
 
 			gotHeaders := w.Header()
+
+			// Always check for Content-Type header
+			contentType := gotHeaders.Get("Content-Type")
+			if contentType != "application/json" {
+				t.Errorf("Content-Type header: want 'application/json', got '%s'", contentType)
+			}
+
+			// Check other expected headers
 			for key, wantValue := range tc.wantHeaders {
 				gotValue := gotHeaders.Get(key)
 				if gotValue != wantValue {
-					t.Errorf("headers %s: want %s, got %s", key, wantValue, gotValue)
+					t.Errorf("header %s: want %s, got %s", key, wantValue, gotValue)
 				}
 			}
 
@@ -131,19 +190,19 @@ func TestInternalServerError_Respond(t *testing.T) {
 			wantCode:    http.StatusInternalServerError,
 			wantHeaders: nil,
 			wantCookies: nil,
-			wantBody:    `{"error":"Internal Server Error"}`,
+			wantBody:    `"Internal Server Error"`,
 		},
 		{
-			desc: "with eveything",
-			given: jsonresp.InternalServerError(errors.New("database failure")).
-				WithHeader("X-Test-1", "test value 1").
+			desc: "with everything",
+			given: jsonresp.InternalServerError(errors.New("database connection failed")).
+				WithHeader("X-Request-ID", "req-123456").
 				WithCookie(cookie),
 			wantCode: http.StatusInternalServerError,
 			wantHeaders: map[string]string{
-				"X-Test-1": "test value 1",
+				"X-Request-ID": "req-123456",
 			},
 			wantCookies: []*http.Cookie{cookie},
-			wantBody:    `{"error":"Internal Server Error"}`,
+			wantBody:    `"Internal Server Error"`,
 		},
 	}
 
@@ -166,10 +225,18 @@ func TestInternalServerError_Respond(t *testing.T) {
 			}
 
 			gotHeaders := w.Header()
+
+			// Always check for Content-Type header
+			gotContentType := gotHeaders.Get("Content-Type")
+			if gotContentType != "application/json" {
+				t.Errorf("Content-Type header: want 'application/json', got '%s'", gotContentType)
+			}
+
+			// Check other expected headers
 			for key, wantValue := range tc.wantHeaders {
 				gotValue := gotHeaders.Get(key)
 				if gotValue != wantValue {
-					t.Errorf("headers %s: want %s, got %s", key, wantValue, gotValue)
+					t.Errorf("header %s: want %s, got %s", key, wantValue, gotValue)
 				}
 			}
 
@@ -192,4 +259,8 @@ func TestInternalServerError_Respond(t *testing.T) {
 			}
 		})
 	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }

--- a/plainresp/error.go
+++ b/plainresp/error.go
@@ -15,16 +15,16 @@ type errorResponder struct {
 	header     http.Header
 	statusCode int
 	cookies    []*http.Cookie
-	errMessage string
+	body       string
 	err        error
 }
 
 // Error creates a new errorResponder with the provided error, message, and status code.
 // The 'err' parameter can be used for internal logging.
-func Error(err error, message string, code int) *errorResponder {
+func Error(err error, body string, code int) *errorResponder {
 	return &errorResponder{
 		statusCode: code,
-		errMessage: message,
+		body:       body,
 		err:        err,
 	}
 }
@@ -34,7 +34,7 @@ func Error(err error, message string, code int) *errorResponder {
 func InternalServerError(err error) *errorResponder {
 	return &errorResponder{
 		statusCode: http.StatusInternalServerError,
-		errMessage: "Internal Server Error",
+		body:       "Internal Server Error",
 		err:        err,
 	}
 }
@@ -54,7 +54,7 @@ func (res *errorResponder) Respond(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	// Set response body and status code.
-	http.Error(w, res.errMessage, res.statusCode)
+	http.Error(w, res.body, res.statusCode)
 	httphandler.LogRequestError(res.logger, res.err)
 }
 


### PR DESCRIPTION
## Summary

This PR removes the constraint that error responses must have a top-level "error" key. Instead, it allows users to define their entire JSON structure for error responses (just like success responses), providing more flexibility.

## Changes

- Refactored `errorResponder` to use the provided data directly without wrapping it in a top-level "error" key
- Enhanced test coverage with more comprehensive test cases for various data types
- Updated examples and documentation to reflect the new approach

## Motivation

When integrating with existing codebases, forcing a specific top-level "error" key can be restrictive. This change allows users to Define their own error response structure completely

## Breaking Changes

Before:

```go
// Using a structured error response
type ValidationError struct {
    Code    string `json:"code"`
    Message string `json:"message"`
    Details string `json:"details,omitempty"`
}

// Error data is automatically wrapped with a top-level "error" key
jsonresp.Error(err, ValidationError{
    Code:    "VALIDATION_ERROR",
    Message: "Invalid input",
    Details: err.Error(),
}, http.StatusBadRequest)

// Response: {"error": {"code": "VALIDATION_ERROR", "message": "Invalid input", "details": "..."}}
```

After:

```go
// Using the same structured error response
type ValidationError struct {
    Code    string `json:"code"`
    Message string `json:"message"`
    Details string `json:"details,omitempty"`
}

// Error data is used directly without wrapping
jsonresp.Error(err, &ValidationError{
    Code:    "VALIDATION_ERROR",
    Message: "Invalid input",
    Details: err.Error(),
}, http.StatusBadRequest)

// Response: {"code": "VALIDATION_ERROR", "message": "Invalid input", "details": "..."}
```

## Testing

Added comprehensive test cases covering various data types and edge cases.

## Migration Guide

To migrate from the previous version:

Simply wrap the error message in a struct or map:

```go
// Before
jsonresp.Error(err, "Error message", statusCode)

// After - Option 1: Using a map
jsonresp.Error(err, &map[string]string{
    "error": "Error message"
}, statusCode)

// After - Option 2: Using a struct
type ErrorResponse struct {
    Error string `json:"error"`
}

jsonresp.Error(err, &ErrorResponse{Error: "Error message"}, statusCode)
```

## Related Issues

Closes #6 
